### PR TITLE
local maven repository in project workspace

### DIFF
--- a/nexus/mvnsettings.xml
+++ b/nexus/mvnsettings.xml
@@ -1,4 +1,7 @@
 <settings>
+  <!--local maven cache needs to be available for each buildpod, so lets put it into the project workspace -->
+  <localRepository>.mvnrepository</localRepository>
+
   <!--This sends everything else to /public -->
   <mirrors>
     <mirror>


### PR DESCRIPTION
This lets the local maven repo to survive between builds, being in the project workspace, which should be on PV.
